### PR TITLE
[cli] Add bin python script to use package CLI.

### DIFF
--- a/bin/http_request_translator
+++ b/bin/http_request_translator
@@ -1,0 +1,49 @@
+#!/usr/bin/python
+import argparse
+
+from http_request_translator.translator import process_arguments
+
+
+def take_arguments():
+    """Entry point for the translator. Parses arguments using `argparse` library.
+
+    :return:`argparse` class object containing arguments passed to the translator.
+    :rtype:class `argparse.Namespace`
+    """
+    parser = argparse.ArgumentParser(
+        description="Request Translator is a standalone tool that can translate "
+                    "raw HTTP requests into curl commands or bash/python/php/ruby/PowerShell scripts")
+    conflicting_group = parser.add_mutually_exclusive_group()
+    parser.add_argument(
+        '--output', '-o',
+        action='append',
+        help="Generates a script for given HTTP request. "
+             "If you want to generate multiple scripts, separate the script's name with a <,>")
+    parser.add_argument(
+        '--proxy', '-p',
+        nargs='?',
+        const='127.0.0.1:8009',
+        help='Generates command/script with relevant, specified proxy')
+    conflicting_group.add_argument(
+        '--search_string', '-ss',
+        help='Sends the request and searches for the required string in the response (i.e literal match)')
+    conflicting_group.add_argument(
+        '--search_regex', '-se',
+        help='Sends the request and searches for the required regex in the response (i.e regex match)')
+    parser.add_argument(
+        '--interactive', '-i',
+        action='store_true',
+        help="Interactive mode: read raw HTTP request from keyboard, hit enter when ready."
+             "Type ':q!' to exit from the interactive mode.")
+    parser.add_argument(
+        '--data', '-d',
+        help='Add the data that you want to send along with the header')
+    parser.add_argument(
+        '--request', '-r',
+        help='Input the HTTP request')
+    process_arguments(parser.parse_args())
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    take_arguments()

--- a/http_request_translator/plugin_manager.py
+++ b/http_request_translator/plugin_manager.py
@@ -1,46 +1,51 @@
 from __future__ import print_function
 
 
-def plugin_manager(script_list, parsed_tuple, searchString=None):
+def hardcoded_script_import(script_name):
+    """Manually import the generate_script function of the script.
+
+    :param str script_name: Name of the script from which to import the function.
+
+    :raises ValueError: When the script is not supported.
+
+    :return: The generate_script function of the `script_name` script.
+    :rtype: function
+    """
+    if script_name == 'bash':
+        from .bash_script import generate_script as gs
+    elif script_name == 'php':
+        from .php_script import generate_script as gs
+    elif script_name == 'python':
+        from .python_script import generate_script as gs
+    elif script_name == 'ruby':
+        from .ruby_script import generate_script as gs
+    else:
+        raise ValueError("The '%s' language is not supported yet." % script_name)
+    return gs
+
+
+def plugin_manager(script_list, parsed_tuple, search_string=None):
     # TODO: Docstring and comments.
     default = len(script_list) or False
     for script in script_list:
-        string = script.lower() + "_script"
+        generate_script = hardcoded_script_import(script.strip().lower())
         header_dict, details_dict = parsed_tuple
-        try:
-            __import__(string, globals={"__name__": __name__}).generate_script(
-                header_dict,
-                details_dict,
-                searchString)
-        except ImportError:
-            print("The support for generating the required Script is not available at the now.")
+        generate_script(header_dict, details_dict, search_string)
     if default:
-        # generates the default Curl command
-        import default
+        # TODO: Generates the default Curl command.
         pass
 
 
-def generate_script(script_type, headers, details, searchString=None):
-    """Returns the script code for the HTTP request passed in `script_type` language
+def generate_script(script, headers, details, search_string=None):
+    """Returns the script code for the HTTP request passed in `script` language
 
-    :param str script_type: Name of the language for which script is to be generated
+    :param str script: Name of the language for which script is to be generated
     :param dict headers: Headers information
     :param dict details: Details information
-    :param str searchString: string to be searched for in the response for given request
+    :param str search_string: string to be searched for in the response for given request
 
     :return: A combined string of generated code
     :rtype:`str`
-
-    .. note::
-
-        script_type cannot be a list, Needed in order to faciliate integration
-
     """
-    script_name = script_type.lower() + "_script"
-    try:
-        return __import__(script_name, globals={"__name__": __name__}).generate_script(
-                headers,
-                details,
-                searchString)
-    except ImportError:
-        raise ImportError("The support for generating the required Script is not available at the time now.")
+    generate_script = hardcoded_script_import(script.strip().lower())
+    return generate_script(headers, details, search_string)

--- a/http_request_translator/translator.py
+++ b/http_request_translator/translator.py
@@ -1,8 +1,6 @@
-#!/usr/bin/python
 from __future__ import print_function
 
 import sys
-import argparse
 try:
     input = raw_input  # Python 2.x
 except NameError:
@@ -14,47 +12,6 @@ except ImportError:
 
 from .plugin_manager import generate_script
 from .url import get_url, check_valid_url
-
-
-def take_arguments():
-    """Entry point for the translator. Parses arguments using `argparse` library.
-
-    :return:`argparse` class object containing arguments passed to the translator.
-    :rtype:class `argparse.Namespace`
-    """
-    parser = argparse.ArgumentParser(
-        description="Request Translator is a standalone tool that can translate "
-                    "raw HTTP requests into curl commands or bash/python/php/ruby/PowerShell scripts")
-    conflicting_group = parser.add_mutually_exclusive_group()
-    parser.add_argument(
-        '--output', '-o',
-        action='append',
-        help="Generates a script for given HTTP request. "
-             "If you want to generate multiple scripts, separate the script's name with a <,>")
-    parser.add_argument(
-        '--proxy', '-p',
-        nargs='?',
-        const='127.0.0.1:8009',
-        help='Generates command/script with relevant, specified proxy')
-    conflicting_group.add_argument(
-        '--search_string', '-ss',
-        help='Sends the request and searches for the required string in the response (i.e literal match)')
-    conflicting_group.add_argument(
-        '--search_regex', '-se',
-        help='Sends the request and searches for the required regex in the response (i.e regex match)')
-    parser.add_argument(
-        '--interactive', '-i',
-        action='store_true',
-        help="Interactive mode: read raw HTTP request from keyboard, hit enter when ready."
-             "Type ':q!' to exit from the interactive mode.")
-    parser.add_argument(
-        '--data', '-d',
-        help='Add the data that you want to send along with the header')
-    parser.add_argument(
-        '--request', '-r',
-        help='Input the HTTP request')
-    process_arguments(parser.parse_args())
-    return parser.parse_args()
 
 
 def process_arguments(args):
@@ -232,9 +189,3 @@ def parse_raw_request(request):
     return header_list, details_dict
 
 
-def main():
-    # TODO: Docstring and comments.
-    take_arguments()
-
-if __name__ == '__main__':
-    main()

--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,14 @@ try:
 except ImportError:
     from distutils.core import setup
 
-setup(name='http_request_translator',
-      version='0.1',
-      description='Translates raw HTTP requests to Python,Ruby,Php and Bash scripts',
-      url='https://github.com/owtf/http-request-translator/',
-      author='Ramana Subramanyam, Arun Sori, cjdupreez',
-      author_email='owasp_owtf_developers@lists.owasp.org',
-      license='3-clause BSD',
-      install_requires=[],
-      packages=['http_request_translator', 'http_request_translator.templates'],
-      )
+setup(
+    name='http_request_translator',
+    version='0.1',
+    description='Translates raw HTTP requests to Python,Ruby,Php and Bash scripts',
+    url='https://github.com/owtf/http-request-translator/',
+    author='Ramana Subramanyam, Arun Sori, cjdupreez',
+    author_email='owasp_owtf_developers@lists.owasp.org',
+    license='3-clause BSD',
+    install_requires=[],
+    packages=['http_request_translator', 'http_request_translator.templates'],
+    scripts=['bin/http_request_translator'])


### PR DESCRIPTION
Quickly:
- Create a python script under ./bin to handle the CLI
- Added `scripts` in setup.py to copy ./bin/ into /bin/

Fixes the broken CLI due to relative import.
