### PR TITLE
Fix escape of data parameter

### DIFF
--- a/http_request_translator/base.py
+++ b/http_request_translator/base.py
@@ -92,7 +92,7 @@ class AbstractScript(object):
         code = ''
         for item in self.headers:
             header, value = item.split(':', 1)
-            code += self.code_header.format(header=header.replace("'", "\'"), value=value.replace("'", "\'"))
+            code += self.code_header.format(header=header.replace("'", "\\'"), value=value.replace("'", "\\'"))
         return code
 
     def _generate_proxy(self):
@@ -111,7 +111,7 @@ class AbstractScript(object):
         :return: Code snippet containing body to be sent in request.
         :rtype: str
         """
-        return self.code_post.format(data=self.details.get('data', '').replace("'", "\'"))
+        return self.code_post.format(data=self.details.get('data', '').replace("'", "\\'"))
 
     def _generate_https(self):
         """Default generation of the HTTPS specific code.
@@ -144,7 +144,7 @@ class AbstractScript(object):
         :return: Code snippet with the HTTP response search feature.
         :rtype: str
         """
-        return self.code_search.format(search_string=search_string.replace("'", "\'"))
+        return self.code_search.format(search_string=search_string.replace("'", "\\'"))
 
     def _generate_nosearch(self):
         """Default generation of the code having no search functionality.

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -26,7 +26,7 @@ class TestScripts(unittest.TestCase):
         self.php_script = script.PHPScript(headers=self.headers, details=self.details)
         self.script_list = [self.ruby_script, self.python_script, self.bash_script, self.php_script]
 
-    def test_generate_search(self):
+    def test_script_generate_search(self):
         for script_name in self.script_list:
             result = script_name._generate_search(self.code_search)
             if isinstance(script_name, script.RubyScript):
@@ -42,7 +42,7 @@ class TestScripts(unittest.TestCase):
                 code_search,
                 'Invalid generation of search code for {}'.format(script_name.__class__.__name__))
 
-    def test_generate_proxy(self):
+    def test_script_generate_proxy(self):
         for script_name in self.script_list:
             result = script_name._generate_proxy()
             if isinstance(script_name, script.RubyScript):
@@ -58,7 +58,7 @@ class TestScripts(unittest.TestCase):
                 code_proxy,
                 'Invalid generation of proxy code for {}'.format(script_name.__class__.__name__))
 
-    def test_generate_script(self):
+    def test_script_generate_script(self):
         for script_name in self.script_list:
             result = script_name.generate_script()
             if isinstance(script_name, script.RubyScript):
@@ -74,7 +74,7 @@ class TestScripts(unittest.TestCase):
                 code,
                 'Invalid generation of script for {}'.format(script_name.__class__.__name__))
 
-    def test_generate_post(self):
+    def test_script_generate_post(self):
         self.details['data'] = 'hello7World\'Ω≈ç√∫˜µ≤≥÷田中さんにあげて下さい,./;[]\-=<>?:"{}|_+!@#$%^&*()`'
         for script_name in self.script_list:
             result = script_name._generate_post()


### PR DESCRIPTION
When factorizing the code base, I made a mistake in `.replace` which broke the proper escaping of the data parameter.

``` bash
$ http_request_translator --output bash --request "POST /tools/http-requests HTTP/1.1
Host: www.codepunker.com
User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:39.0) Gecko/20100101 Firefox/39.0
Accept: */*
Accept-Language: en-US,en;q=0.5
Accept-Encoding: gzip, deflate
DNT: 1
Content-Type: application/x-www-form-urlencoded
Connection: keep-alive
Pragma: no-cache
Cache-Control: no-cache" --data "extra=test'test" -ss 'ss'





#!/usr/bin/env bash
curl --data 'extra=test'test' -v --request POST http://www.codepunker.com/tools/http-requests  --header 'Host: www.codepunker.com'  --header 'User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:39.0) Gecko/20100101 Firefox/39.0'  --header 'Accept: */*'  --header 'Accept-Language: en-US,en;q=0.5'  --header 'Accept-Encoding: gzip, deflate'  --header 'DNT: 1'  --header 'Content-Type: application/x-www-form-urlencoded'  --header 'Connection: keep-alive'  --header 'Pragma: no-cache'  --header 'Cache-Control: no-cache'  --include | egrep --color ' ss |$'
```

This PR fixes the bug by replacing `.replace("'", "\'")` with `.replace("'", "\\'")`
